### PR TITLE
Clamp final player velocity to prevent mach 10 launches

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -553,7 +553,7 @@ public class PlayerController : MonoBehaviour
 
                 Vector2 testPos = relPos + _velocity * Time.fixedDeltaTime;
                 Vector2 newPos = testPos.normalized * _swingRadius;
-                _velocity = (newPos - relPos) / Time.fixedDeltaTime;
+                _velocity = Vector2.ClampMagnitude((newPos - relPos) / Time.fixedDeltaTime, maxSwingSpeed);
             }
         }
         else if (PlayerState is PlayerStateEnum.Swing && !_isButtonHeld)


### PR DESCRIPTION
## Description
Clamps the final velocity of the swing to prevent this case:
1. Player enters trigger
2. Player is outside of radius but collider still overlaps (since capsule is like 2 meters tall)
3. Player starts swing
4. Relative velocity to be set to the correct relative position makes you have 100+ velocity
5. Player exits swing next tick
6. Player gets launched at mach 10

## Before and After

## Checklist
- [X] This code builds and runs
- [X] All public classes and methods are documented
- [X] Hard-to-understand areas of the code are documented
- [X] Self-review done
