### PR TITLE
Fix: editor for cloth/zipper (hopefully), resets for zipper/blocks

### DIFF
--- a/Assets/Editor/AttachableMovingObjectEditor.cs
+++ b/Assets/Editor/AttachableMovingObjectEditor.cs
@@ -9,25 +9,34 @@ namespace Editor
     [CustomEditor(typeof(AttachableMovingObject)), CanEditMultipleObjects]
     public class AttachableMovingObjectEditor : UnityEditor.Editor
     {
+        private SerializedProperty firstPositionProperty;
+        private SerializedProperty secondPositionProperty;
+        
+        private void OnEnable()
+        {
+            firstPositionProperty = serializedObject.FindProperty(nameof(AttachableMovingObject.firstPosition));
+            secondPositionProperty = serializedObject.FindProperty(nameof(AttachableMovingObject.secondPosition));
+        }
+
         /// <inheritdoc />
         public override void OnInspectorGUI()
         {
             base.OnInspectorGUI();
 
             if (targets.Length > 1) return;
-
             AttachableMovingObject attachableMovingObject = target as AttachableMovingObject;
             if (attachableMovingObject == null) return;
+            serializedObject.Update();
 
             if (GUILayout.Button("Set First Position As Current"))
             {
-                attachableMovingObject.firstPosition = attachableMovingObject.transform.position;
+                firstPositionProperty.vector2Value= attachableMovingObject.transform.position;
                 serializedObject.ApplyModifiedProperties();
             }
 
             if (GUILayout.Button("Set Second Position As Current"))
             {
-                attachableMovingObject.secondPosition = attachableMovingObject.transform.position;
+                secondPositionProperty.vector2Value= attachableMovingObject.transform.position;
                 serializedObject.ApplyModifiedProperties();
             }
 

--- a/Assets/Editor/ClothObstacleHiderEditor.cs
+++ b/Assets/Editor/ClothObstacleHiderEditor.cs
@@ -9,6 +9,15 @@ namespace Editor
     [CustomEditor(typeof(ClothObstacleHider)), CanEditMultipleObjects]
     public class ClothObstacleHiderEditor : UnityEditor.Editor
     {
+        private SerializedProperty firstPositionProperty;
+        private SerializedProperty secondPositionProperty;
+        
+        private void OnEnable()
+        {
+            firstPositionProperty = serializedObject.FindProperty(nameof(ClothObstacleHider.firstPosition));
+            secondPositionProperty = serializedObject.FindProperty(nameof(ClothObstacleHider.secondPosition));
+        }
+        
         /// <inheritdoc />
         public override void OnInspectorGUI()
         {
@@ -21,13 +30,13 @@ namespace Editor
 
             if (GUILayout.Button("Set First Position As Current"))
             {
-                hider.firstPosition = hider.transform.localPosition;
+                firstPositionProperty.vector2Value= hider.transform.localPosition;
                 serializedObject.ApplyModifiedProperties();
             }
 
             if (GUILayout.Button("Set Second Position As Current"))
             {
-                hider.secondPosition = hider.transform.localPosition;
+                secondPositionProperty.vector2Value= hider.transform.localPosition;
                 serializedObject.ApplyModifiedProperties();
             }
 

--- a/Assets/Prefabs/LetterBlock.prefab
+++ b/Assets/Prefabs/LetterBlock.prefab
@@ -111,6 +111,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  dashEndTolerance: 1
 --- !u!212 &7907048460438451200
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -177,6 +178,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   letter: {fileID: 9049336575698353907}
   particles: {fileID: 4573120003948009498}
+  childRenderers:
+  - {fileID: 5443037520854214380}
   blockBreakDelay: 0.25
   delayBetweenShakes: 0.002
   distance: 0.5
@@ -5108,7 +5111,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fadeDuration: 0.3
-  destroyOnFadeOut: 1
+  deactivateOnFade: 0
+  destroyOnFade: 0
 --- !u!1 &9049336575698353907
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AttachableMovingObject.cs
+++ b/Assets/Scripts/AttachableMovingObject.cs
@@ -253,10 +253,24 @@ public class AttachableMovingObject : AbstractPlayerInteractable
     {
         StopMotion();
     }
+    
+    /// <summary>
+    /// Called on reset: resets back to the first position.
+    /// </summary>
+    private void OnReset()
+    {
+        transform.position = firstPosition;
+    }
 
     private void Awake()
     {
         _rigidbody = GetComponent<Rigidbody2D>();
+        GameManager.Instance.Reset += OnReset;
+    }
+
+    private void OnDisable()
+    {
+        GameManager.Instance.Reset -= OnReset;
     }
 
     private void OnValidate()

--- a/Assets/Scripts/ClothObstacleHider.cs
+++ b/Assets/Scripts/ClothObstacleHider.cs
@@ -80,6 +80,26 @@ public class ClothObstacleHider : MonoBehaviour
     }
 
     /// <summary>
+    /// Called on reset: stops motion and resets to the start.
+    /// </summary>
+    private void OnReset()
+    {
+        transform.localPosition = firstPosition;
+        if (_activeMotion != null) StopCoroutine(_activeMotion);
+        _activeMotion = null;
+    }
+
+    private void Awake()
+    {
+        GameManager.Instance.Reset += OnReset;
+    }
+
+    private void OnDisable()
+    {
+        GameManager.Instance.Reset -= OnReset;
+    }
+
+    /// <summary>
     /// Starts moving from the first position.
     /// </summary>
     [UsedImplicitly]

--- a/Assets/Scripts/DashDestructibleObject.cs
+++ b/Assets/Scripts/DashDestructibleObject.cs
@@ -17,6 +17,21 @@ public class DashDestructibleObject : MonoBehaviour
     private void Awake()
     {
         _collider = GetComponent<Collider2D>();
+        GameManager.Instance.Reset += OnReset;
+    }
+
+    /// <summary>
+    /// Called on reset: re-enables the collider.
+    /// </summary>
+    private void OnReset()
+    {
+        destroyed = false;
+        _collider.enabled = true;
+    }
+
+    private void OnDisable()
+    {
+        GameManager.Instance.Reset -= OnReset;
     }
 
     /// <summary>

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -8,7 +8,15 @@ using Action = System.Action;
 /// </summary>
 public class GameManager : MonoBehaviour
 {
-    public static GameManager Instance { get; private set; }
+    private static GameManager _instance;
+
+    /// <summary>
+    /// Finds the singleton in the scene if present.
+    /// </summary>
+    /// <remarks>
+    /// Bypasses the lifetime check since it's DontDestroyOnLoad.
+    /// </remarks>
+    public static GameManager Instance => _instance ??= FindObjectOfType<GameManager>();
 
     /// <summary>
     /// Last checkpoint position. The player should respawn here if they die.
@@ -32,16 +40,15 @@ public class GameManager : MonoBehaviour
 
     private void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            SceneManager.sceneLoaded += OnSceneLoaded;
-        }
-        else
+        if (_instance != null && _instance != this)
         {
             Destroy(gameObject);
+            return;
         }
+        
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+        SceneManager.sceneLoaded += OnSceneLoaded;
     }
 
     private void Update()

--- a/Assets/Scripts/LetterBlock.cs
+++ b/Assets/Scripts/LetterBlock.cs
@@ -9,8 +9,9 @@ public class LetterBlock : MonoBehaviour
 {
     [SerializeField] private GameObject letter;
     [SerializeField] private GameObject particles;
+    [SerializeField] private SpriteRenderer[] childRenderers;
     [SerializeField] [Min(0)] private float blockBreakDelay;
-    [SerializeField] [Range(0f, 0.1f)] private float delayBetweenShakes = 0f;
+    [SerializeField] [Range(0f, 0.1f)] private float delayBetweenShakes;
     [SerializeField] [Range(0f, 2f)] private float distance = 0.1f;
 
     private SpriteRenderer _renderer;
@@ -18,6 +19,23 @@ public class LetterBlock : MonoBehaviour
     private void Awake()
     {
         _renderer = GetComponent<SpriteRenderer>();
+        GameManager.Instance.Reset += OnReset;
+    }
+
+    /// <summary>
+    /// Called on reset: hides the particles and enables the renderers.
+    /// </summary>
+    private void OnReset()
+    {
+        particles.SetActive(false);
+        _renderer.enabled = true;
+        letter.SetActive(true);
+        foreach (SpriteRenderer childRenderer in childRenderers) childRenderer.enabled = true;
+    }
+
+    private void OnDisable()
+    {
+        GameManager.Instance.Reset -= OnReset;
     }
 
     public void Crack()
@@ -55,6 +73,8 @@ public class LetterBlock : MonoBehaviour
         _renderer.enabled = false;
         letter.SetActive(false);
         // Give time for particles to spawn, then destroy object and children
-        Destroy(gameObject, blockBreakDelay / 2);
+        yield return new WaitForSeconds(blockBreakDelay / 2f);
+        particles.SetActive(false);
+        foreach (SpriteRenderer childRenderer in childRenderers) childRenderer.enabled = false;
     }
 }


### PR DESCRIPTION
## Description
What changes does this PR include? Is there anything that affects other features that people should be aware of?
- hopefully the editor buttons actually work now — got rekt serializedObject vs target bs again (
- Zipper/blocks now properly reset
  - Note blocks don't destroy anymore after they're gone, so that's unused memory of like 4 KB tops
- Fixed an issue with the GameManager singleton lol

## Before and After

https://github.com/user-attachments/assets/a116b5eb-7bbb-47c6-8674-b1e23f86d1f7

## Checklist
- [X] This code builds and runs
- [X] All public classes and methods are documented
- [X] Hard-to-understand areas of the code are documented
- [X] Self-review done
