### PR TITLE
make it all use scaled time again

### DIFF
--- a/Assets/Scripts/Yarn/LineView.cs
+++ b/Assets/Scripts/Yarn/LineView.cs
@@ -278,7 +278,7 @@ namespace Yarn
         /// <summary>
         ///     A stop token that is used to interrupt the current animation.
         /// </summary>
-        private readonly UnscaledEffects.CoroutineInterruptToken currentStopToken = new();
+        private readonly ScaledEffects.CoroutineInterruptToken currentStopToken = new();
 
         /// <summary>
         ///     The current <see cref="LocalizedLine" /> that this line view is
@@ -299,8 +299,8 @@ namespace Yarn
 
         private void Update()
         {
-            // if hitting spacebar during update, trigger dialogue advancement
-            if (Input.GetButtonDown("Jump")) UserRequestedViewAdvancement();
+            // if hitting spacebar during update and not paused, trigger dialogue advancement
+            if (Input.GetButtonDown("Jump") && Time.timeScale != 0) UserRequestedViewAdvancement();
         }
 
         /// <inheritdoc />
@@ -315,14 +315,14 @@ namespace Yarn
         {
             // disabling interaction temporarily while dismissing the line
             // we don't want people to interrupt a dismissal
-            var interactable = canvasGroup.interactable;
+            bool interactable = canvasGroup.interactable;
             canvasGroup.interactable = false;
 
             // If we're using a fade effect, run it, and wait for it to finish.
             if (useFadeEffect)
             {
                 yield return
-                    StartCoroutine(UnscaledEffects.FadeAlpha(canvasGroup, 1, 0, fadeOutTime, currentStopToken));
+                    StartCoroutine(ScaledEffects.FadeAlpha(canvasGroup, 1, 0, fadeOutTime, currentStopToken));
                 currentStopToken.Complete();
             }
 
@@ -395,7 +395,7 @@ namespace Yarn
 
         private void UpdateAvatarAndName(LocalizedLine dialogueLine)
         {
-            var charName = dialogueLine.CharacterName.Split("_", 2);
+            string[] charName = dialogueLine.CharacterName.Split("_", 2);
             // we have a character name text view, show the character name
 
             characterNameText.text = charName[0];
@@ -418,19 +418,15 @@ namespace Yarn
                 // we have one).
                 continueButton?.SetActive(false);
 
-                var text = dialogueLine.TextWithoutCharacterName;
+                MarkupParseResult text = dialogueLine.TextWithoutCharacterName;
                 if (characterNameContainer && characterNameText)
                 {
                     // we are set up to show a character name, but there isn't one
                     // so just hide the container
                     if (string.IsNullOrWhiteSpace(dialogueLine.CharacterName))
-                    {
                         characterNameContainer.SetActive(false);
-                    }
                     else
-                    {
                         UpdateAvatarAndName(dialogueLine);
-                    }
                 }
                 else
                 {
@@ -458,7 +454,7 @@ namespace Yarn
                 // finish.
                 if (useFadeEffect)
                 {
-                    yield return StartCoroutine(UnscaledEffects.FadeAlpha(canvasGroup, 0, 1, fadeInTime,
+                    yield return StartCoroutine(ScaledEffects.FadeAlpha(canvasGroup, 0, 1, fadeInTime,
                         currentStopToken));
                     if (currentStopToken.WasInterrupted)
                         // The fade effect was interrupted. Stop this entire
@@ -470,14 +466,14 @@ namespace Yarn
                 // it to finish.
                 if (useTypewriterEffect)
                 {
-                    var pauses = GetPauseDurationsInsideLine(text);
+                    Stack<(int position, float duration)> pauses = GetPauseDurationsInsideLine(text);
 
                     // setting the canvas all back to its defaults because if we didn't also fade we don't have anything visible
                     canvasGroup.alpha = 1f;
                     canvasGroup.interactable = true;
                     canvasGroup.blocksRaycasts = true;
 
-                    yield return StartCoroutine(UnscaledEffects.PausableTypewriter(
+                    yield return StartCoroutine(ScaledEffects.PausableTypewriter(
                         lineText,
                         typewriterEffectSpeed,
                         () => onCharacterTyped.Invoke(),
@@ -591,12 +587,12 @@ namespace Yarn
         private static string PaletteMarkedUpText(MarkupParseResult line, MarkupPalette palette,
             bool applyLineBreaks = true)
         {
-            var lineOfText = line.Text;
+            string lineOfText = line.Text;
             line.Attributes.Sort((a, b) => b.Position.CompareTo(a.Position));
-            foreach (var attribute in line.Attributes)
+            foreach (MarkupAttribute attribute in line.Attributes)
             {
                 // we have a colour that matches the current marker
-                if (palette.ColorForMarker(attribute.Name, out var markerColour))
+                if (palette.ColorForMarker(attribute.Name, out Color markerColour))
                 {
                     // we use the range on the marker to insert the TMP <color> tags
                     // not the best approach but will work ok for this use case
@@ -614,7 +610,7 @@ namespace Yarn
 
         private static string AddLineBreaks(MarkupParseResult line)
         {
-            var lineOfText = line.Text;
+            string lineOfText = line.Text;
             line.Attributes.Sort((a, b) => b.Position.CompareTo(a.Position));
             return line.Attributes.Where(a => a.Name == "br").Aggregate(lineOfText,
                 (current, attribute) => current.Insert(attribute.Position, "<br>"));
@@ -624,7 +620,7 @@ namespace Yarn
         ///     Creates a stack of typewriter pauses to use to temporarily halt the typewriter effect.
         /// </summary>
         /// <remarks>
-        ///     This is intended to be used in conjunction with the <see cref="UnscaledEffects.PausableTypewriter" /> effect.
+        ///     This is intended to be used in conjunction with the <see cref="ScaledEffects.PausableTypewriter" /> effect.
         ///     The stack of tuples created are how the typewriter effect knows when, and for how long, to halt the effect.
         ///     <para>
         ///         The pause duration property is in milliseconds but all the effects code assumes seconds
@@ -635,19 +631,19 @@ namespace Yarn
         /// <returns>A stack of positions and duration pause tuples from within the line</returns>
         public static Stack<(int position, float duration)> GetPauseDurationsInsideLine(MarkupParseResult line)
         {
-            var pausePositions = new Stack<(int, float)>();
+            Stack<(int, float)> pausePositions = new();
             const string label = "pause";
 
             // sorting all the attributes in reverse positional order
             // this is so we can build the stack up in the right positioning
-            var attributes = line.Attributes;
+            List<MarkupAttribute> attributes = line.Attributes;
             attributes.Sort((a, b) => b.Position.CompareTo(a.Position));
-            foreach (var attribute in line.Attributes.Where(attribute => attribute.Name == label))
+            foreach (MarkupAttribute attribute in line.Attributes.Where(attribute => attribute.Name == label))
                 // did they set a custom duration or not, as in did they do this:
                 //     Alice: this is my line with a [pause = 1000 /]pause in the middle
                 // or did they go:
                 //     Alice: this is my line with a [pause /]pause in the middle
-                if (attribute.Properties.TryGetValue(label, out var value))
+                if (attribute.Properties.TryGetValue(label, out MarkupValue value))
                     // depending on the property value we need to take a different path
                     // this is because they have made it an integer or a float which are roughly the same
                     // note to self: integer and float really ought to be convertible...

--- a/Assets/Scripts/Yarn/ScaledEffects.cs
+++ b/Assets/Scripts/Yarn/ScaledEffects.cs
@@ -229,9 +229,9 @@ namespace Yarn
                     if (pausePositions != null && pausePositions.Count != 0)
                         if (text.maxVisibleCharacters == pausePositions.Peek().Item1)
                         {
-                            (int position, float duration) pause = pausePositions.Pop();
+                            (_, float duration) = pausePositions.Pop();
                             onPauseStarted?.Invoke();
-                            yield return InterruptableWait(pause.Item2, stopToken);
+                            yield return InterruptableWait(duration, stopToken);
                             onPauseEnded?.Invoke();
 
                             // need to reset the accumulator

--- a/Assets/Scripts/Yarn/ScaledEffects.cs
+++ b/Assets/Scripts/Yarn/ScaledEffects.cs
@@ -14,7 +14,7 @@ namespace Yarn
     ///     Contains coroutine methods that apply visual effects. This class is used
     ///     by <see cref="LineView" /> to handle animating the presentation of lines.
     /// </summary>
-    public static class UnscaledEffects
+    public static class ScaledEffects
     {
         /// <summary>
         ///     A coroutine that fades a <see cref="CanvasGroup" /> object's opacity
@@ -43,16 +43,16 @@ namespace Yarn
 
             canvasGroup.alpha = from;
 
-            var timeElapsed = 0f;
+            float timeElapsed = 0f;
 
             while (timeElapsed < fadeTime)
             {
                 if (stopToken?.WasInterrupted ?? false) yield break;
 
-                var fraction = timeElapsed / fadeTime;
-                timeElapsed += Time.unscaledDeltaTime;
+                float fraction = timeElapsed / fadeTime;
+                timeElapsed += Time.deltaTime;
 
-                var a = Mathf.Lerp(from, to, fraction);
+                float a = Mathf.Lerp(from, to, fraction);
 
                 canvasGroup.alpha = a;
                 yield return null;
@@ -141,7 +141,7 @@ namespace Yarn
                 if (stopToken?.WasInterrupted ?? false) yield break;
 
                 yield return null;
-                accumulator += Time.unscaledDeltaTime;
+                accumulator += Time.deltaTime;
             }
         }
 
@@ -149,7 +149,7 @@ namespace Yarn
         ///     A coroutine that gradually reveals the text in a <see cref="TextMeshProUGUI" /> object over time.
         /// </summary>
         /// <remarks>
-        ///     Essentially identical to <see cref="UnscaledEffects.Typewriter" /> but supports pausing the animation based on
+        ///     Essentially identical to <see cref="ScaledEffects.Typewriter" /> but supports pausing the animation based on
         ///     <paramref name="pausePositions" /> values.
         ///     <para>
         ///         This method works by adjusting the value of the <paramref name="text" /> parameter's
@@ -190,7 +190,7 @@ namespace Yarn
             yield return null;
 
             // How many visible characters are present in the text?
-            var characterCount = text.textInfo.characterCount;
+            int characterCount = text.textInfo.characterCount;
 
             // Early out if letter speed is zero, text length is zero
             if (lettersPerSecond <= 0 || characterCount == 0)
@@ -202,7 +202,7 @@ namespace Yarn
             }
 
             // Convert 'letters per second' into its inverse
-            var secondsPerLetter = 1.0f / lettersPerSecond;
+            float secondsPerLetter = 1.0f / lettersPerSecond;
 
             // If lettersPerSecond is larger than the average framerate, we
             // need to show more than one letter per frame, so simply
@@ -213,7 +213,7 @@ namespace Yarn
             // Instead, we'll accumulate time every frame, and display as
             // many letters in that frame as we need to in order to achieve
             // the requested speed.
-            var accumulator = Time.unscaledDeltaTime;
+            float accumulator = Time.deltaTime;
 
             while (text.maxVisibleCharacters < characterCount)
             {
@@ -229,31 +229,30 @@ namespace Yarn
                     if (pausePositions != null && pausePositions.Count != 0)
                         if (text.maxVisibleCharacters == pausePositions.Peek().Item1)
                         {
-                            var pause = pausePositions.Pop();
+                            (int position, float duration) pause = pausePositions.Pop();
                             onPauseStarted?.Invoke();
                             yield return InterruptableWait(pause.Item2, stopToken);
                             onPauseEnded?.Invoke();
 
                             // need to reset the accumulator
-                            accumulator = Time.unscaledDeltaTime;
+                            accumulator = Time.deltaTime;
                         }
 
                     text.maxVisibleCharacters += 1;
 
                     onCharacterTyped?.Invoke();
                     accumulator -= secondsPerLetter;
-                    
+
                     // Don't pause on the last character
                     if (text.maxVisibleCharacters >= characterCount) continue;
 
                     // Extra pause on punctuation
-                    var nextChar = text.text[text.maxVisibleCharacters - 1];
-                    if (nextChar.Equals('.') || nextChar.Equals(',') || nextChar.Equals('?') || nextChar.Equals('!')) {
+                    char nextChar = text.text[text.maxVisibleCharacters - 1];
+                    if (nextChar.Equals('.') || nextChar.Equals(',') || nextChar.Equals('?') || nextChar.Equals('!'))
                         yield return new WaitForSecondsRealtime(0.3f);
-                    }
                 }
 
-                accumulator += Time.unscaledDeltaTime;
+                accumulator += Time.deltaTime;
 
                 yield return null;
             }

--- a/Assets/Scripts/Yarn/ScaledEffects.cs.meta
+++ b/Assets/Scripts/Yarn/ScaledEffects.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b4c6936089be44d1858f45ac40dc6198
+timeCreated: 1743826835

--- a/Assets/Scripts/Yarn/UnscaledEffects.cs.meta
+++ b/Assets/Scripts/Yarn/UnscaledEffects.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: c461786a84cb41759252871de5f7278b
-timeCreated: 1729308935


### PR DESCRIPTION
## Description
What changes does this PR include? Is there anything that affects other features that people should be aware of?
- change cutscenes to use `deltaTime` instead of `unscaledDeltaTime`
- check for `timeScale != 0` when triggering continue button

## Before and After
Screenshots/videos of the changes:

## Checklist
- [x] This code builds and runs
- [x] All public classes and methods are documented
- [x] Hard-to-understand areas of the code are documented
- [x] Self-review done
