### PR TITLE
Custom tutorial text + position

### DIFF
--- a/Assets/Prefabs/Core/Manager.prefab
+++ b/Assets/Prefabs/Core/Manager.prefab
@@ -1283,7 +1283,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 140}
-  m_SizeDelta: {x: 200, y: 50}
+  m_SizeDelta: {x: 300, y: 50}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &4272199004796768725
 CanvasRenderer:
@@ -1340,8 +1340,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 32
+  m_fontSizeBase: 28
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/Assets/Prefabs/Core/Manager.prefab
+++ b/Assets/Prefabs/Core/Manager.prefab
@@ -1316,7 +1316,7 @@ MonoBehaviour:
   m_text: New Text
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 2f52c711435458a42914b2d292c5070e, type: 2}
-  m_sharedMaterial: {fileID: -1518737356106722432, guid: 2f52c711435458a42914b2d292c5070e, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: ca2ee1b35786018419f1592185771700, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/Prefabs/Core/Manager.prefab
+++ b/Assets/Prefabs/Core/Manager.prefab
@@ -1248,6 +1248,140 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!1 &2324734304226654232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6388075704606397666}
+  - component: {fileID: 4272199004796768725}
+  - component: {fileID: 8827033900195061305}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6388075704606397666
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2324734304226654232}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8831398549011400782}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 140}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &4272199004796768725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2324734304226654232}
+  m_CullTransparentMesh: 1
+--- !u!114 &8827033900195061305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2324734304226654232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 2f52c711435458a42914b2d292c5070e, type: 2}
+  m_sharedMaterial: {fileID: -1518737356106722432, guid: 2f52c711435458a42914b2d292c5070e, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 1024
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2388886692989948515
 GameObject:
   m_ObjectHideFlags: 0
@@ -1281,7 +1415,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3493627082972880179}
+  - {fileID: 8831398549011400782}
   m_Father: {fileID: 5675118328201374811}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1376,6 +1510,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b857d7247ed42fab3d5a73f43b6d8f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  tutorialBox: {fileID: 8782046399898052886}
+  tutorialTextbox: {fileID: 8827033900195061305}
   animator: {fileID: 1887150882908468052}
   fadeDuration: 0.5
 --- !u!1 &2404451183240866013
@@ -2373,7 +2509,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &3493627082972880179
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2381,19 +2517,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4689895050892069843}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1667882653604221177}
-  m_Father: {fileID: 5388266479587086588}
+  m_Children: []
+  m_Father: {fileID: 8831398549011400782}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 90, y: 70}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 330, y: 160}
-  m_Pivot: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &425540184753936311
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2422,7 +2557,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: -172568243, guid: 7f9be731f78aeda408074d4daabc0dc3, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -3728,18 +3863,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6992185647170036276}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3493627082972880179}
+  m_Father: {fileID: 8831398549011400782}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -120}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 70}
   m_SizeDelta: {x: 140, y: 140}
-  m_Pivot: {x: 0.5, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8062011286938856775
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3768,7 +3903,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
+  m_Sprite: {fileID: -1435485583, guid: b7c86cda58369a6448426f99e751c5d1, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
   m_FillCenter: 1
@@ -4324,6 +4459,65 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8782046399898052886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8831398549011400782}
+  - component: {fileID: 1395999423591143802}
+  m_Layer: 5
+  m_Name: TutorialBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8831398549011400782
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8782046399898052886}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3493627082972880179}
+  - {fileID: 1667882653604221177}
+  - {fileID: 6388075704606397666}
+  m_Father: {fileID: 5388266479587086588}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 350, y: 300}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1395999423591143802
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8782046399898052886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &8843247259574805729
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -111670,11 +111670,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 742586270503421809, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 65.100006
+      value: 114.06
       objectReference: {fileID: 0}
     - target: {fileID: 742586270503421809, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 12.3
+      value: 30.66
       objectReference: {fileID: 0}
     - target: {fileID: 742586270503421809, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_LocalPosition.z
@@ -111783,7 +111783,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4544653655168585683, guid: d896cfaf134fcf742b43b825c3882308, type: 3}
       propertyPath: m_Name
-      value: CheckpointFlag (0)
+      value: CheckpointFlag (0) (BreakBlock)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -111816,6 +111816,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tutorialMove: breakBlock
+  tutorialText: Dash to break blocks
+  tutorialPosition: {x: 300, y: 0}
   tutorialEnd: {fileID: 435875637}
 --- !u!1001 &458754246
 PrefabInstance:
@@ -121915,7 +121917,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4544653655168585683, guid: d896cfaf134fcf742b43b825c3882308, type: 3}
       propertyPath: m_Name
-      value: CheckpointFlag (4)
+      value: CheckpointFlag (4) (Zipper)
       objectReference: {fileID: 0}
     - target: {fileID: 8572367019768239859, guid: d896cfaf134fcf742b43b825c3882308, type: 3}
       propertyPath: respawnFacingLeft
@@ -121952,6 +121954,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tutorialMove: zipper
+  tutorialText: 'Hold to zip
+
+    Release to launch'
+  tutorialPosition: {x: 360, y: 0}
   tutorialEnd: {fileID: 1584507853}
 --- !u!1001 &1277853034
 PrefabInstance:
@@ -124912,19 +124918,19 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 485476076255008130, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_Size.x
-      value: 12
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 485476076255008130, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_Size.y
-      value: 12
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 742586270503421809, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 409.3
+      value: 401
       objectReference: {fileID: 0}
     - target: {fileID: 742586270503421809, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 184.4
+      value: 227
       objectReference: {fileID: 0}
     - target: {fileID: 742586270503421809, guid: 8b7a73a2733b56447817b14efc15d9bb, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Scenes/Level2.unity
+++ b/Assets/Scenes/Level2.unity
@@ -111817,7 +111817,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   tutorialMove: breakBlock
   tutorialText: Dash to break blocks
-  tutorialPosition: {x: 300, y: 0}
+  tutorialPosition: {x: 400, y: 0}
   tutorialEnd: {fileID: 435875637}
 --- !u!1001 &458754246
 PrefabInstance:

--- a/Assets/Scripts/UI/TutorialMenu.cs
+++ b/Assets/Scripts/UI/TutorialMenu.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Linq;
+using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -12,7 +13,8 @@ namespace UI
     public class TutorialMenu : MonoBehaviour
     {
         private static TutorialMenu _instance;
-
+        [SerializeField] private GameObject tutorialBox;
+        [SerializeField] private TMP_Text tutorialTextbox;
         [SerializeField] private Animator animator;
 
         [SerializeField] [Min(0)] [Tooltip("Fade duration (sec)")]
@@ -53,26 +55,34 @@ namespace UI
         private void OnSceneChanged(Scene current, Scene next)
         {
             _canvasGroup.alpha = 0;
-            animator.gameObject.SetActive(false);
+            tutorialBox.SetActive(false);
         }
 
         /// <summary>
         ///     Shows the tutorial with the given tutorial name (as defined in the animation controller).
         /// </summary>
         /// <param name="tutorialName">Tutorial name as specified in the animation controller</param>
-        public void ShowTutorial(string tutorialName)
+        /// <param name="tutorialText">Text to display for tutorial move</param>
+        /// <param name="tutorialPosition">Position to show the tutorial, relative to the center of the screen</param>
+        public void ShowTutorial(Vector2 tutorialPosition, string tutorialName, string tutorialText = "")
         {
             int tutorialNameHash = Animator.StringToHash(tutorialName);
-            animator.gameObject.SetActive(true);
+            tutorialBox.SetActive(true);
             // reading parameters requires the animator object to be active
             if (animator.parameters.All(parameter => parameter.nameHash != tutorialNameHash))
             {
                 Debug.LogError("Invalid tutorial move set " + tutorialName);
-                animator.gameObject.SetActive(false);
+                tutorialBox.SetActive(false);
                 return;
             }
 
+            tutorialBox.transform.localPosition = new Vector3(
+                tutorialPosition.x,
+                tutorialPosition.y,
+                tutorialBox.transform.position.z
+            );
             animator.SetTrigger(tutorialNameHash);
+            tutorialTextbox.text = tutorialText;
 
             if (_fadeInCoroutine != null)
                 StopCoroutine(_fadeInCoroutine);
@@ -120,7 +130,7 @@ namespace UI
             }
 
             _canvasGroup.alpha = 0;
-            animator.gameObject.SetActive(false);
+            tutorialBox.SetActive(false);
         }
     }
 }

--- a/Assets/Scripts/UI/TutorialMenu.cs
+++ b/Assets/Scripts/UI/TutorialMenu.cs
@@ -82,7 +82,7 @@ namespace UI
                 tutorialBox.transform.position.z
             );
             animator.SetTrigger(tutorialNameHash);
-            tutorialTextbox.text = tutorialText;
+            tutorialTextbox.text = tutorialText.Replace("\n", "\n");
 
             if (_fadeInCoroutine != null)
                 StopCoroutine(_fadeInCoroutine);

--- a/Assets/Scripts/UI/TutorialStart.cs
+++ b/Assets/Scripts/UI/TutorialStart.cs
@@ -9,7 +9,7 @@ namespace UI
     {
         [SerializeField] private string tutorialMove;
 
-        [Tooltip("Text to display for tutorial move")] [SerializeField]
+        [Tooltip("Text to display for tutorial move")] [SerializeField] [TextArea(0, 3)]
         private string tutorialText;
 
         [Tooltip("Position to show the tutorial, relative to the center of the screen")] [SerializeField]

--- a/Assets/Scripts/UI/TutorialStart.cs
+++ b/Assets/Scripts/UI/TutorialStart.cs
@@ -3,14 +3,20 @@ using UnityEngine;
 namespace UI
 {
     /// <summary>
-    /// Attached to a box collider region to start showing a tutorial move
+    ///     Attached to a box collider region to start showing a tutorial move
     /// </summary>
     public class TutorialStart : MonoBehaviour
     {
         [SerializeField] private string tutorialMove;
 
-        [Tooltip("When the player reaches this game object's region, it'll hide the tutorial")]
-        [SerializeField] private TutorialEnd tutorialEnd;
+        [Tooltip("Text to display for tutorial move")] [SerializeField]
+        private string tutorialText;
+
+        [Tooltip("Position to show the tutorial, relative to the center of the screen")] [SerializeField]
+        private Vector2 tutorialPosition;
+
+        [Tooltip("When the player reaches this game object's region, it'll hide the tutorial")] [SerializeField]
+        private TutorialEnd tutorialEnd;
 
         private void Awake()
         {
@@ -21,7 +27,7 @@ namespace UI
         private void OnTriggerEnter2D(Collider2D other)
         {
             if (!other.CompareTag("Player") || tutorialMove == "") return;
-            TutorialMenu.Instance.ShowTutorial(tutorialMove);
+            TutorialMenu.Instance.ShowTutorial(tutorialPosition, tutorialMove, tutorialText);
             tutorialMove = "";
         }
     }

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/Pangolin-Regular SDF Shadow.mat
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/Pangolin-Regular SDF Shadow.mat
@@ -1,0 +1,111 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Pangolin-Regular SDF Shadow
+  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - UNDERLAY_ON
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Cube:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FaceTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 2888493809570264722, guid: 2f52c711435458a42914b2d292c5070e, type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OutlineTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Ambient: 0.5
+    - _Bevel: 0.5
+    - _BevelClamp: 0
+    - _BevelOffset: 0
+    - _BevelRoundness: 0
+    - _BevelWidth: 0
+    - _BumpFace: 0
+    - _BumpOutline: 0
+    - _ColorMask: 15
+    - _CullMode: 0
+    - _Diffuse: 0.5
+    - _FaceDilate: 0.5
+    - _FaceUVSpeedX: 0
+    - _FaceUVSpeedY: 0
+    - _GlowInner: 0.05
+    - _GlowOffset: 0
+    - _GlowOuter: 0.05
+    - _GlowPower: 0.75
+    - _GradientScale: 6
+    - _LightAngle: 3.1416
+    - _MaskSoftnessX: 0
+    - _MaskSoftnessY: 0
+    - _OutlineSoftness: 0
+    - _OutlineUVSpeedX: 0
+    - _OutlineUVSpeedY: 0
+    - _OutlineWidth: 0.5
+    - _PerspectiveFilter: 0.875
+    - _Reflectivity: 10
+    - _ScaleRatioA: 0.8333333
+    - _ScaleRatioB: 0.46875
+    - _ScaleRatioC: 0.46875
+    - _ScaleX: 1
+    - _ScaleY: 1
+    - _ShaderFlags: 0
+    - _Sharpness: 0
+    - _SpecularPower: 2
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _TextureHeight: 512
+    - _TextureWidth: 512
+    - _UnderlayDilate: 0.4
+    - _UnderlayOffsetX: 0
+    - _UnderlayOffsetY: 0
+    - _UnderlaySoftness: 0.2
+    - _VertexOffsetX: 0
+    - _VertexOffsetY: 0
+    - _WeightBold: 0.75
+    - _WeightNormal: 0
+    m_Colors:
+    - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _EnvMatrixRotation: {r: 0, g: 0, b: 0, a: 0}
+    - _FaceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _GlowColor: {r: 0, g: 1, b: 0, a: 0.5}
+    - _MaskCoord: {r: 0, g: 0, b: 32767, a: 32767}
+    - _OutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ReflectFaceColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ReflectOutlineColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
+    - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.7058824}
+  m_BuildTextureStacks: []

--- a/Assets/TextMesh Pro/Resources/Fonts & Materials/Pangolin-Regular SDF Shadow.mat.meta
+++ b/Assets/TextMesh Pro/Resources/Fonts & Materials/Pangolin-Regular SDF Shadow.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca2ee1b35786018419f1592185771700
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
What changes does this PR include? Is there anything that affects other features that people should be aware of?
- Allow configuration of tutorial position + additional text
- Place the tutorials in level 1 and 2 near the relevant obstacles and add text explanation for each

NOTE: Please playtest before approving! Let me know if I need to reposition any of the tutorials. Also, playtest on both desktop + mobile plz <3

## Before and After
Screenshots/videos of the changes:
![image](https://github.com/user-attachments/assets/ce949d34-6f2d-482d-8847-cf6104e9be2f)

## Checklist
- [x] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
- [x] This code builds and runs
- [x] All public classes and methods are documented
- [x] Hard-to-understand areas of the code are documented
- [x] Self-review done
