### PR TITLE
Implement count-up

### DIFF
--- a/Assets/Prefabs/Core/Manager.prefab
+++ b/Assets/Prefabs/Core/Manager.prefab
@@ -2726,17 +2726,6 @@ MonoBehaviour:
   - preLevelCutscene: 
     levelName: Level4
     postLevelCutscene: EndCutscene
-  levelNameList:
-  - Level1Trial
-  - Level2
-  - Level3
-  - Level4
-  cutsceneNameList:
-  - IntroCutscene
-  - SecondCutscene
-  - Level2InterstitialCutscene
-  - EndCutscene
-  - MainMenu
 --- !u!82 &2257474230385962516
 AudioSource:
   m_ObjectHideFlags: 0
@@ -3209,15 +3198,15 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1520.4772
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 629.4004
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.0863606
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Prefabs/Core/Results Manager.prefab
+++ b/Assets/Prefabs/Core/Results Manager.prefab
@@ -31,7 +31,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -164,11 +164,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3071732409571947957}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -200, y: 0}
-  m_SizeDelta: {x: 182.57, y: 182.5705}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 180, y: 180}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5471723365520751846
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -234,16 +234,16 @@ RectTransform:
   m_GameObject: {fileID: 1699028471991051657}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.75, y: 0.75, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6873810669834456800}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -200, y: 0}
-  m_SizeDelta: {x: 182.57, y: 182.5705}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 137, y: 137}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5064622545332417394
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -314,11 +314,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 8875640666073706122}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 109.32, y: -0.0000095367}
-  m_SizeDelta: {x: 329.4274, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -218, y: 100}
+  m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &8243150649734597297
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -446,13 +446,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 273}
-  m_SizeDelta: {x: 884.1358, y: 114.4023}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -35}
+  m_SizeDelta: {x: 0, y: 124.9}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1042341644032654283
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -561,6 +561,7 @@ GameObject:
   - component: {fileID: 1122380346237911815}
   - component: {fileID: 7333847050746320412}
   - component: {fileID: 6680832005780494842}
+  - component: {fileID: 885800262240374863}
   m_Layer: 5
   m_Name: Count
   m_TagString: Untagged
@@ -582,11 +583,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 6873810669834456800}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -70, y: 0}
-  m_SizeDelta: {x: 411.338, y: 113.73}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 170, y: 0}
+  m_SizeDelta: {x: 250, y: 113.73}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &7333847050746320412
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -649,7 +650,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 1
   m_VerticalAlignment: 4096
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -684,6 +685,21 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &885800262240374863
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2960980651637686469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2ebe60dd3124c1898f3d3e1f0e76466, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  deathCountRate: 4
+  collectibleMaxDuration: 1.2
+  timeBetweenCollectibleAudio: 0.15
 --- !u!1 &3410946196948061372
 GameObject:
   m_ObjectHideFlags: 0
@@ -714,12 +730,12 @@ RectTransform:
   m_Children:
   - {fileID: 5100770232856161393}
   - {fileID: 1317651476111877640}
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -267, y: 108}
-  m_SizeDelta: {x: 621.22, y: 113.7316}
+  m_AnchoredPosition: {x: -248, y: 108}
+  m_SizeDelta: {x: 621.22, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3460405037983618707
 GameObject:
@@ -752,7 +768,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -882,13 +898,20 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1029556703193674426}
+  - {fileID: 3071732409571947957}
+  - {fileID: 6873810669834456800}
+  - {fileID: 8875640666073706122}
+  - {fileID: 7802736904195356367}
+  - {fileID: 6944440268107621215}
+  - {fileID: 2828628100639538790}
   m_Father: {fileID: 5950538738849536759}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 8.9908, y: 0}
-  m_SizeDelta: {x: 1208.1156, y: 743.6694}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -690, y: -336}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2136011762147484426
 CanvasRenderer:
@@ -954,7 +977,7 @@ Transform:
   m_GameObject: {fileID: 4579114898537606062}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1520.4772, y: 629.4004, z: -1.0863606}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -976,11 +999,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   finalCheckpoint: {fileID: 0}
-  resultsPane: {fileID: 5041319373685722033}
-  levelHeaderText: {fileID: 2333283121882461431}
-  collectableResultsText: {fileID: 7615747715308610474}
-  deathsText: {fileID: 6680832005780494842}
-  timerText: {fileID: 185908790033053836}
+  resultsWindow: {fileID: 6823790342341326098}
 --- !u!1 &4689274418804491040
 GameObject:
   m_ObjectHideFlags: 0
@@ -1127,13 +1146,14 @@ GameObject:
   - component: {fileID: 5780545025074761255}
   - component: {fileID: 3288284184004507178}
   - component: {fileID: 57275433414428476}
+  - component: {fileID: 6823790342341326098}
   m_Layer: 0
   m_Name: Results Window
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5950538738849536759
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1147,13 +1167,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 736787490885685709}
-  - {fileID: 1029556703193674426}
-  - {fileID: 3071732409571947957}
-  - {fileID: 6873810669834456800}
-  - {fileID: 8875640666073706122}
-  - {fileID: 7802736904195356367}
-  - {fileID: 6944440268107621215}
-  - {fileID: 2828628100639538790}
   m_Father: {fileID: 1620775784866583158}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1224,6 +1237,22 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &6823790342341326098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5041319373685722033}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f307901b9a8c421788545faebb2eae91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  levelHeaderText: {fileID: 2333283121882461431}
+  timerText: {fileID: 185908790033053836}
+  collectableResultsText: {fileID: 4746023229530521899}
+  deathsText: {fileID: 885800262240374863}
 --- !u!1 &5610196180187258651
 GameObject:
   m_ObjectHideFlags: 0
@@ -1247,19 +1276,19 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5610196180187258651}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2202401328059474640}
   - {fileID: 3311714533607285104}
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000022888, y: -33}
-  m_SizeDelta: {x: 548.0756, y: 100}
+  m_AnchoredPosition: {x: 0, y: -33}
+  m_SizeDelta: {x: 550, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6069616718889879248
 GameObject:
@@ -1293,11 +1322,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 8875640666073706122}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -173.57, y: -0.0000095367}
-  m_SizeDelta: {x: 199.6138, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 100}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &4830046764386048455
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1426,7 +1455,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1585,6 +1614,7 @@ GameObject:
   - component: {fileID: 1317651476111877640}
   - component: {fileID: 122353442190151703}
   - component: {fileID: 7615747715308610474}
+  - component: {fileID: 4746023229530521899}
   m_Layer: 5
   m_Name: Count
   m_TagString: Untagged
@@ -1606,11 +1636,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 3071732409571947957}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 60, y: 0}
-  m_SizeDelta: {x: 411.338, y: 113.73}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 165, y: 0}
+  m_SizeDelta: {x: 420, y: 125}
+  m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &122353442190151703
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1708,6 +1738,21 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &4746023229530521899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7405495558609697867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2ebe60dd3124c1898f3d3e1f0e76466, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  deathCountRate: 4
+  collectibleMaxDuration: 1.2
+  timeBetweenCollectibleAudio: 0.15
 --- !u!1 &8164705121069188491
 GameObject:
   m_ObjectHideFlags: 0
@@ -1840,10 +1885,10 @@ RectTransform:
   m_Children:
   - {fileID: 4801008026253324070}
   - {fileID: 1122380346237911815}
-  m_Father: {fileID: 5950538738849536759}
+  m_Father: {fileID: 736787490885685709}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 473, y: 118}
-  m_SizeDelta: {x: 621.22, y: 113.7316}
+  m_SizeDelta: {x: 540, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Scenes/Level2InterstitialCutscene.unity
+++ b/Assets/Scenes/Level2InterstitialCutscene.unity
@@ -96043,79 +96043,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 1030365878134251738, guid: d0738f8adb5244ba0a5801b609442fc4, type: 3}
   m_PrefabInstance: {fileID: 36154283}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &56040703
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1520.4772
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 629.4004
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.0863606
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1620775784866583158, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4579114898537606062, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_Name
-      value: Results Manager
-      objectReference: {fileID: 0}
-    - target: {fileID: 4579114898537606062, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7499476184492949100, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: gameManager
-      value: 
-      objectReference: {fileID: 1588058012}
-    - target: {fileID: 7499476184492949100, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: finalCheckpoint
-      value: 
-      objectReference: {fileID: 1759429192}
-    - target: {fileID: 7499476184492949100, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
-      propertyPath: collectableResults
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: dd796b62e71897f40b9dc32c7f7c24a4, type: 3}
 --- !u!1001 &513485964
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -96777,6 +96704,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8321333269778309438, guid: 3c94b1314f832f84ca7de56231cf1b3a, type: 3}
+      propertyPath: finalCheckpoint
+      value: 
+      objectReference: {fileID: 1759429192}
     - target: {fileID: 8542332163250851050, guid: 3c94b1314f832f84ca7de56231cf1b3a, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -96794,17 +96725,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3c94b1314f832f84ca7de56231cf1b3a, type: 3}
---- !u!114 &1588058012 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5130713523581019797, guid: 3c94b1314f832f84ca7de56231cf1b3a, type: 3}
-  m_PrefabInstance: {fileID: 1588058011}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1d47a2663ac469a49a589388c2c56409, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1631008776
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -97175,4 +97095,3 @@ SceneRoots:
   - {fileID: 513485964}
   - {fileID: 1111688093}
   - {fileID: 1828552501}
-  - {fileID: 56040703}

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -231,20 +231,19 @@ namespace Managers
             }
         }
         
-        // <summary>
-        // signals that the level is completed and the level data should be saved
-        // called by resultsManager once last checkpoint is reached
-        // </summary>
-        public void LevelCompleted()
+        /// <summary>
+        /// Saves level data - called by resultsManager once last checkpoint is reached.
+        /// </summary>
+        public void SaveGame()
         {
             SaveLevelDataToGameManager();
             saveGame?.Invoke();
         }
 
-        // <summary>
-        // saves all of the current game stats (thisLevelDeaths, thisLevelCandies, thisLevelTime)
-        // to the game manager level data variables
-        // </summary>
+        /// <summary>
+        /// saves all of the current game stats (thisLevelDeaths, thisLevelCandies, thisLevelTime)
+        /// to the game manager level data variables
+        /// </summary>
         private void SaveLevelDataToGameManager()
         {
             int idx = SceneListManager.Instance.LevelNumber;

--- a/Assets/Scripts/Managers/SoundManager.cs
+++ b/Assets/Scripts/Managers/SoundManager.cs
@@ -98,6 +98,14 @@ namespace Managers
         }
 
         /// <summary>
+        /// Resets the time since last collect.
+        /// </summary>
+        public void ResetTimeSinceLastCollect()
+        {
+            _timeSinceLastCollect = Mathf.Infinity;
+        }
+
+        /// <summary>
         /// Plays a collectable sound in sequence with combo logic using PlayOneShot.
         /// </summary>
         public void PlayCollectableComboSound()

--- a/Assets/Scripts/UI/CountUpText.cs
+++ b/Assets/Scripts/UI/CountUpText.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections;
+using Managers;
+using TMPro;
+using UnityEngine;
+
+namespace UI
+{
+    /// <summary>
+    /// Text to count up to a number in the final results menu page.
+    /// </summary>
+    [RequireComponent(typeof(TextMeshProUGUI))]
+    public class CountUpText : MonoBehaviour
+    {
+        [SerializeField] private float deathCountRate = 4f;
+        [SerializeField] private float collectibleMaxDuration = 1.2f;
+        [SerializeField]
+        private float timeBetweenCollectibleAudio = 0.15f;
+        private TextMeshProUGUI _text;
+
+        private void Awake()
+        {
+            _text = GetComponent<TextMeshProUGUI>();
+        }
+
+        /// <summary>
+        /// Starts counting up to the number from 0 at <see cref="deathCountRate"/> units/sec.
+        /// </summary>
+        /// <param name="number">Target final number</param>
+        public void RunCountUpWithRate(int number)
+        {
+            StartCoroutine(CountUpRateCoroutine(number));
+        }
+
+        /// <summary>
+        /// Starts counting up to (number / max) from 0 with fixed duration <see cref="collectibleMaxDuration"/>.
+        /// </summary>
+        /// <param name="number"></param>
+        /// <param name="max"></param>
+        public void RunCountUpForCollectible(int number, int max)
+        {
+            StartCoroutine(CountUpForCollectible(number, max));
+        }
+
+        /// <summary>
+        /// Coroutine to count up to a target number from 0 at <see cref="deathCountRate"/> units/sec.
+        /// </summary>
+        /// <param name="toMax">Target number</param>
+        /// <returns>Coroutine</returns>
+        private IEnumerator CountUpRateCoroutine(int toMax)
+        {
+            float time = 0;
+            for (int curr = 0; curr <= toMax; curr = Mathf.Min(toMax, Mathf.RoundToInt(deathCountRate * time)),
+                 time += Time.unscaledDeltaTime)
+            {
+                _text.text = curr.ToString();
+                yield return null;
+            }
+            _text.text = toMax.ToString();
+        }
+
+        /// <summary>
+        /// Coroutine to count up to (number / max) from 0 with fixed duration <see cref="collectibleMaxDuration"/>.
+        /// </summary>
+        /// <param name="number">Number to count to</param>
+        /// <param name="max">Maximum</param>
+        /// <returns>Coroutine</returns>
+        private IEnumerator CountUpForCollectible(int number, int max)
+        {
+            SoundManager.Instance.ResetTimeSinceLastCollect();
+            for (float time = 0, timeToNextPlay = 0; time < collectibleMaxDuration; time += Time.unscaledDeltaTime)
+            {
+                int curr = Mathf.Min(number, Mathf.RoundToInt(max * time / collectibleMaxDuration));
+                if (curr == number) break;
+                _text.text = $"{curr} / {max}";
+                timeToNextPlay -= Time.unscaledDeltaTime;
+                if (timeToNextPlay <= 0)
+                {
+                    SoundManager.Instance.PlayCollectableComboSound();
+                    timeToNextPlay = timeBetweenCollectibleAudio;
+                }
+                yield return null;
+            }
+            _text.text = $"{number} / {max}";
+        }
+    }
+}

--- a/Assets/Scripts/UI/CountUpText.cs.meta
+++ b/Assets/Scripts/UI/CountUpText.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a2ebe60dd3124c1898f3d3e1f0e76466
+timeCreated: 1754349897

--- a/Assets/Scripts/UI/ResultsWindow.cs
+++ b/Assets/Scripts/UI/ResultsWindow.cs
@@ -1,0 +1,37 @@
+﻿using Managers;
+using TMPro;
+using UnityEngine;
+
+namespace UI
+{
+    /// <summary>
+    /// Main behaviour for the results window.
+    /// </summary>
+    public class ResultsWindow : MonoBehaviour
+    {
+        [SerializeField] private TextMeshProUGUI levelHeaderText;
+        [SerializeField] private TextMeshProUGUI timerText;
+        [SerializeField] private CountUpText collectableResultsText;
+        [SerializeField] private CountUpText deathsText;
+        
+        /// <summary>
+        /// Updates the displayed values.
+        /// </summary>
+        public void UpdateDisplay()
+        {
+            levelHeaderText.text = $"Level {SceneListManager.Instance.LevelNumber} Complete!";
+            collectableResultsText.RunCountUpForCollectible(GameManager.Instance.NumCollectablesCollected,
+                GameManager.Instance.MaxCollectablesCount);
+            
+            int deaths = GameManager.Instance.thisLevelDeaths;
+            //if uninstantiated and still null value
+            if (deaths == -1)
+            {
+                deaths = 0;
+                Debug.LogWarning("GameManager death count uninstantiated?");
+            }
+            deathsText.RunCountUpWithRate(deaths);
+            timerText.text = TimerManager.ElapsedLevelTimeString;
+        }
+    }
+}

--- a/Assets/Scripts/UI/ResultsWindow.cs.meta
+++ b/Assets/Scripts/UI/ResultsWindow.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f307901b9a8c421788545faebb2eae91
+timeCreated: 1754350933


### PR DESCRIPTION
## Description
- collectible count at the end counts up
- and death as well
- oh and for some reason level 2 interstitial cutscene has 2 results managers so i fixed that
- qol can now optionally wait for 1 fixed update tick

## Before and After
https://github.com/user-attachments/assets/1d3df353-4f4d-4ba4-ac23-9feae1881f09

## Checklist (for devs)
- [X] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
   - I WAS THERE WHEN IT WAS WRITTEN
- [X] Tested changes in Unity
- [X] Prefab overrides are applied or reverted where relevant
- [X] All meta files are committed
- [X] Checked Github's "Files changed" tab for unintended changes
- [X] Files, classes, and complex methods are documented 
