### PR TITLE
Greyscale Collecable After Death

### DIFF
--- a/Assets/Scripts/Interactables/Collectable.cs
+++ b/Assets/Scripts/Interactables/Collectable.cs
@@ -55,16 +55,6 @@ namespace Interactables
             _collider.enabled = false;
         }
 
-        // /// <summary>
-        // /// Resets the collectable to default
-        // /// </summary>
-        // public void ResetCollectable()
-        // {
-        //     _isCollected = false;
-        //     _spriteRenderer.enabled = true;
-        //     _spriteRenderer.color = Color.white;
-        // }
-
         private void OnValidate()
         {
             _spriteRenderer = GetComponent<SpriteRenderer>();

--- a/Assets/Scripts/Interactables/Collectable.cs
+++ b/Assets/Scripts/Interactables/Collectable.cs
@@ -1,6 +1,9 @@
+using System;
 using Managers;
+using Player;
 using UnityEngine;
 using Util;
+using Random = UnityEngine.Random;
 
 namespace Interactables
 {
@@ -14,12 +17,53 @@ namespace Interactables
         
         private SpriteRenderer _spriteRenderer;
         private Collider2D _collider;
+        private PlayerController player;
+        private bool _isCollected;
         
         private void Awake()
         {
             _collider = GetComponent<Collider2D>();
             _spriteRenderer = GetComponent<SpriteRenderer>();
+            player = FindObjectOfType<PlayerController>();
+            _isCollected = false;
         }
+
+        private void OnEnable()
+        {
+            player.Death += OnPlayerDeath;
+        }
+
+        private void OnPlayerDeath()
+        {
+            if (_isCollected) GreyOut();
+        }
+
+        private void Collect()
+        {
+            // TODO: play a visual/particle effect before destroying
+            GameManager.Instance.CollectCollectable(this);
+            SoundManager.Instance.PlayCollectableComboSound();
+            _isCollected = true;
+            _spriteRenderer.enabled = false;
+            _collider.enabled = false;
+        }
+        
+        private void GreyOut()
+        {
+            _spriteRenderer.enabled = true;
+            _spriteRenderer.color = Color.gray;
+            _collider.enabled = false;
+        }
+
+        // /// <summary>
+        // /// Resets the collectable to default
+        // /// </summary>
+        // public void ResetCollectable()
+        // {
+        //     _isCollected = false;
+        //     _spriteRenderer.enabled = true;
+        //     _spriteRenderer.color = Color.white;
+        // }
 
         private void OnValidate()
         {
@@ -28,13 +72,9 @@ namespace Interactables
         
         private void OnTriggerEnter2D(Collider2D other)
         {
-            if (other.CompareTag("Player"))
+            if (other.CompareTag("Player") && !_isCollected)
             {
-                GameManager.Instance.CollectCollectable(this);
-                // TODO: play a visual/particle effect before destroying
-                SoundManager.Instance.PlayCollectableComboSound();
-                _spriteRenderer.enabled = false;
-                _collider.enabled = false;
+                Collect();
             }
         }
 

--- a/Assets/Scripts/Interactables/Collectable.cs
+++ b/Assets/Scripts/Interactables/Collectable.cs
@@ -15,24 +15,24 @@ namespace Interactables
         
         private SpriteRenderer _spriteRenderer;
         private Collider2D _collider;
-        private PlayerController _player;
+        private GameManager _gameManager;
         private bool _isCollected;
         
         private void Awake()
         {
             _collider = GetComponent<Collider2D>();
             _spriteRenderer = GetComponent<SpriteRenderer>();
-            _player = FindObjectOfType<PlayerController>();
+            _gameManager = GameManager.Instance;
             _isCollected = false;
-            _player.Death += OnPlayerDeath;
+            _gameManager.Reset += OnReset;
         }
 
         private void OnDestroy()
         {
-            _player.Death -= OnPlayerDeath;
+            _gameManager.Reset -= OnReset;
         }
 
-        private void OnPlayerDeath()
+        private void OnReset()
         {
             if (_isCollected) GreyOut();
         }
@@ -51,7 +51,8 @@ namespace Interactables
         {
             _spriteRenderer.enabled = true;
             _spriteRenderer.color = Color.gray;
-            _collider.enabled = false;
+            _collider.enabled = true;
+            Debug.Log("Collectable Greyed Out");
         }
 
         private void OnValidate()
@@ -61,7 +62,7 @@ namespace Interactables
         
         private void OnTriggerEnter2D(Collider2D other)
         {
-            if (other.CompareTag("Player") && !_isCollected)
+            if (other.CompareTag("Player"))
             {
                 Collect();
             }

--- a/Assets/Scripts/Interactables/Collectable.cs
+++ b/Assets/Scripts/Interactables/Collectable.cs
@@ -1,9 +1,7 @@
-using System;
 using Managers;
 using Player;
 using UnityEngine;
 using Util;
-using Random = UnityEngine.Random;
 
 namespace Interactables
 {
@@ -17,20 +15,21 @@ namespace Interactables
         
         private SpriteRenderer _spriteRenderer;
         private Collider2D _collider;
-        private PlayerController player;
+        private PlayerController _player;
         private bool _isCollected;
         
         private void Awake()
         {
             _collider = GetComponent<Collider2D>();
             _spriteRenderer = GetComponent<SpriteRenderer>();
-            player = FindObjectOfType<PlayerController>();
+            _player = FindObjectOfType<PlayerController>();
             _isCollected = false;
+            _player.Death += OnPlayerDeath;
         }
 
-        private void OnEnable()
+        private void OnDestroy()
         {
-            player.Death += OnPlayerDeath;
+            _player.Death -= OnPlayerDeath;
         }
 
         private void OnPlayerDeath()

--- a/Assets/Scripts/Interactables/Collectable.cs
+++ b/Assets/Scripts/Interactables/Collectable.cs
@@ -50,7 +50,7 @@ namespace Interactables
         private void GreyOut()
         {
             _spriteRenderer.enabled = true;
-            _spriteRenderer.color = Color.gray;
+            _spriteRenderer.color = new Color(1.0f, 1.0f, 1.0f, 0.3f);
             _collider.enabled = true;
             Debug.Log("Collectable Greyed Out");
         }

--- a/Assets/Scripts/Interactables/Collectable.cs
+++ b/Assets/Scripts/Interactables/Collectable.cs
@@ -40,7 +40,7 @@ namespace Interactables
         private void Collect()
         {
             // TODO: play a visual/particle effect before destroying
-            GameManager.Instance.CollectCollectable(this);
+            if (!_isCollected) GameManager.Instance.CollectCollectable(this);
             SoundManager.Instance.PlayCollectableComboSound();
             _isCollected = true;
             _spriteRenderer.enabled = false;


### PR DESCRIPTION
## Description
<!-- What changes does this PR include? Is there anything that affects other features that people should be aware of? -->
- On first time collected, candy disappears
- After death, the candy collider is disabled and greyed out
- All code changes are in the collectable script, subscribing to the player death event and greys out once dies

## Before and After
<!-- Screenshots/videos of the changes: -->
https://github.com/user-attachments/assets/c1e9c4f5-4758-4b21-a014-bb3217f4793e



## Checklist (for devs)
- [x] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
- [x] Tested changes in Unity
- [x] Prefab overrides are applied or reverted where relevant
- [x] All meta files are committed
- [x] Checked Github's "Files changed" tab for unintended changes
- [x] Files, classes, and complex methods are documented 
