### PR TITLE
Cutscene fixes

### DIFF
--- a/Assets/Story/Level2Script.yarn
+++ b/Assets/Story/Level2Script.yarn
@@ -78,7 +78,7 @@ setting: a cliff
 <<wait 0.05>>
 <<leap_nonblock Knitby -25 18 0.37 false -66 true true true>>
 <<fade_in 0.25>>
-<<fix_coords 74 678 1>>F
+<<fix_coords 74 678 1>>
 <<wait_move_finish Knitby>>
 // Knitby and Marshmallow jump up together
 <<leap_nonblock Marshmallow -25 18 0.37 false -66 true>>

--- a/Assets/Story/Summit.yarn
+++ b/Assets/Story/Summit.yarn
@@ -3,7 +3,7 @@ setting: the summit of mt. stringmore
 ---
 <<animator_set_bool Marshmallow Hang true>>
 <<fix_coords 0 1.5>>
-<<resize_camera 8 10>>
+<<resize_camera 8 100>>
 <<shiver Knitby 0.05 0.05>>
 <<wait 0.3>>
 <<fade_in>>

--- a/Assets/Story/Summit.yarn
+++ b/Assets/Story/Summit.yarn
@@ -3,6 +3,7 @@ setting: the summit of mt. stringmore
 ---
 <<animator_set_bool Marshmallow Hang true>>
 <<fix_coords 0 1.5>>
+<<resize_camera 8 10>>
 <<shiver Knitby 0.05 0.05>>
 <<wait 0.3>>
 <<fade_in>>


### PR DESCRIPTION
## Description
<!-- What changes does this PR include? Is there anything that affects other features that people should be aware of? -->
- Fix overly zoomed in Level4 cutscene https://discordapp.com/channels/1291594634384117810/1396582580618530907/1411807442844520491
- Fix "F" on Level2Interstitial https://discordapp.com/channels/1291594634384117810/1396582580618530907/1411803407550779533

## Before and After
<!-- Screenshots/videos of the changes: -->
<img width="615" height="343" alt="image" src="https://github.com/user-attachments/assets/81664701-c8b9-44e0-aa03-b9cd9e2744d9" />


## Checklist (for devs)
- [x] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
- [x] Tested changes in Unity
- [x] Prefab overrides are applied or reverted where relevant
- [x] All meta files are committed
- [x] Checked Github's "Files changed" tab for unintended changes
- [x] Files, classes, and complex methods are documented 
