### PR TITLE
Cutscene updates

### DIFF
--- a/Assets/Scenes/Cutscene5.unity
+++ b/Assets/Scenes/Cutscene5.unity
@@ -325,7 +325,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2905708094114413808, guid: acfb9aa2be1d44e8f8a92767af27c906, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -18.04
+      value: -19.04
       objectReference: {fileID: 0}
     - target: {fileID: 2905708094114413808, guid: acfb9aa2be1d44e8f8a92767af27c906, type: 3}
       propertyPath: m_LocalPosition.y
@@ -459,7 +459,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7720336601314418461, guid: ec97a70a79f3542a2b4d7c736da0849e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -20.080002
+      value: -21.08
       objectReference: {fileID: 0}
     - target: {fileID: 7720336601314418461, guid: ec97a70a79f3542a2b4d7c736da0849e, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Scenes/IntroCutscene.unity
+++ b/Assets/Scenes/IntroCutscene.unity
@@ -3929,7 +3929,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 715592302039424758, guid: ae467fca31521479d920e449f3fcb866, type: 3}
       propertyPath: orthographic size
-      value: 7
+      value: 6.5
       objectReference: {fileID: 0}
     - target: {fileID: 3630413941472142713, guid: ae467fca31521479d920e449f3fcb866, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Story/Level1Script.yarn
+++ b/Assets/Story/Level1Script.yarn
@@ -1,6 +1,7 @@
 ﻿title: IntroCutscene
 setting: outside Knitby's house
 ---
+<<resize_camera 6.5 100>>
 <<fix_coords 6.9 2>>
 <<move Marshmallow 2 1 15 true>>
 // marshmallow knocks on Knitby's door

--- a/Assets/Story/Level4Script.yarn
+++ b/Assets/Story/Level4Script.yarn
@@ -1,5 +1,6 @@
 ﻿title: Level4Cutscene
 ---
+<<resize_camera 8 100>>
 <<fix_coords 0 0>>
 <<fade_in>>
 Marshmallow: I see the exit!


### PR DESCRIPTION
## Description
<!-- What changes does this PR include? Is there anything that affects other features that people should be aware of? -->
- Move things and/or resize camera in cutscenes so that nothing looks chopped on mobile
- Add camera size to start of yarn scripts, because sometimes it doesn't reset in between cutscenes and there's an awkward zoom at the start of the cutscene

## Before and After
<!-- Screenshots/videos of the changes: -->
<img width="1101" height="691" alt="Screenshot 2025-09-05 193635" src="https://github.com/user-attachments/assets/a206c76e-bcde-44b3-b0df-a50279ab938b" />
<img width="926" height="658" alt="Screenshot 2025-09-05 193408" src="https://github.com/user-attachments/assets/5f4c27b7-b3fd-4e4f-a217-8010dbbe5418" />

## Checklist (for devs)
- [x] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
- [x] Tested changes in Unity
- [x] Prefab overrides are applied or reverted where relevant
- [x] All meta files are committed
- [x] Checked Github's "Files changed" tab for unintended changes
- [x] Files, classes, and complex methods are documented 
