### PR TITLE
String rendering animation

### DIFF
--- a/Assets/Prefabs/Core/Player.prefab
+++ b/Assets/Prefabs/Core/Player.prefab
@@ -164,8 +164,6 @@ MonoBehaviour:
   - {fileID: 8300000, guid: c81b8a0512e132e4cbdff16ff3c341e9, type: 3}
   - {fileID: 8300000, guid: e9de9b181cfc6804e9e615db52c9d7ad, type: 3}
   hangOffset: {x: 0, y: 0}
-  swingDeltaMultiplier: 0.5
-  speedRingSpeedThreshold: 31
   roastColors:
   - {r: 1, g: 1, b: 1, a: 1}
   - {r: 1, g: 0.90081525, b: 0.75, a: 1}
@@ -299,8 +297,9 @@ MonoBehaviour:
   maxHackAcceleration: 200
   hackVelocityRatio: 0.8
   hackRange: 0.4
+  swingDeltaMultiplier: 0.5
   runParticleVelocityThreshold: 0.1
-  ropeRenderer: {fileID: 8739561083334380143}
+  ropeRenderer: {fileID: 783731139087979784}
   deathTime: 1
   poofSmoke: {fileID: 3003327103453879542, guid: e52706b0a1958aa4fa0aa6a37ce53810, type: 3}
   swingAttach: {fileID: 8300000, guid: c34be067950c0494cb0a29b36dd18775, type: 3}
@@ -619,6 +618,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1310921584863302646}
   - component: {fileID: 8739561083334380143}
+  - component: {fileID: 783731139087979784}
   m_Layer: 7
   m_Name: RopeDrawer
   m_TagString: Untagged
@@ -745,6 +745,20 @@ LineRenderer:
   m_UseWorldSpace: 1
   m_Loop: 0
   m_ApplyActiveColorSpace: 1
+--- !u!114 &783731139087979784
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8704445144224804026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82fcbdc2eeb8af3409ddc0e898105c1e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ropeGrowDuration: 0.3
+  growFromSelfToAttachPoint: 1
 --- !u!1001 &598642433859097067
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Placeable/Balloon.prefab
+++ b/Assets/Prefabs/Placeable/Balloon.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 5067567272399834472}
   - component: {fileID: 3573509288529436064}
   - component: {fileID: 1927134968448480249}
-  - component: {fileID: 1170907410447028140}
   - component: {fileID: 7366023542971264359}
   m_Layer: 0
   m_Name: Balloon
@@ -38,6 +37,7 @@ Transform:
   m_Children:
   - {fileID: 7788834244580457418}
   - {fileID: 2506166215833608769}
+  - {fileID: 5568727172324842435}
   m_Father: {fileID: 6009844562311201391}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!58 &6042588307930732201
@@ -350,14 +350,74 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!120 &1170907410447028140
+--- !u!210 &7366023542971264359
+SortingGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88623153598989244}
+  m_Enabled: 1
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_SortAtRoot: 0
+--- !u!1 &1150463583432144520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5568727172324842435}
+  - component: {fileID: 2587185230638297681}
+  - component: {fileID: 7973507517121089164}
+  m_Layer: 0
+  m_Name: RopeRenderer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5568727172324842435
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150463583432144520}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6743220846621682762}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2587185230638297681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150463583432144520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82fcbdc2eeb8af3409ddc0e898105c1e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ropeGrowDuration: 0.3
+  growFromSelfToAttachPoint: 1
+  useWorldSpace: 0
+--- !u!120 &7973507517121089164
 LineRenderer:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 88623153598989244}
+  m_GameObject: {fileID: 1150463583432144520}
   m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -454,18 +514,6 @@ LineRenderer:
   m_UseWorldSpace: 0
   m_Loop: 0
   m_ApplyActiveColorSpace: 1
---- !u!210 &7366023542971264359
-SortingGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 88623153598989244}
-  m_Enabled: 1
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_SortAtRoot: 0
 --- !u!1 &2343643655324065570
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Interactables/Balloon/Balloon.cs
+++ b/Assets/Scripts/Interactables/Balloon/Balloon.cs
@@ -11,7 +11,7 @@ namespace Interactables.Balloon
     /// <summary>
     /// Balloon interactable.
     /// </summary>
-    [RequireComponent(typeof(Rigidbody2D), typeof(LineRenderer))]
+    [RequireComponent(typeof(Rigidbody2D))]
     public class Balloon : AbstractPlayerInteractable
     {
         [Header("Motion")]
@@ -116,7 +116,7 @@ namespace Interactables.Balloon
         private Coroutine _resetCoroutine;
 
         private Rigidbody2D _rigidbody;
-        private LineRenderer _lineRenderer;
+        private RopeRenderer _ropeRenderer;
         private BalloonFunnyVisual _balloonFunnyVisual;
         private BalloonVisual balloonVisual;
         private PlayerController _player;
@@ -124,7 +124,7 @@ namespace Interactables.Balloon
         private void Awake()
         {
             _rigidbody = GetComponent<Rigidbody2D>();
-            _lineRenderer = GetComponent<LineRenderer>();
+            _ropeRenderer = GetComponentInChildren<RopeRenderer>();
             balloonVisual = GetComponentInChildren<BalloonVisual>(true);
             _balloonFunnyVisual = GetComponentInChildren<BalloonFunnyVisual>(true);
             GameManager.Instance.Reset += RespawnBalloon;
@@ -271,8 +271,7 @@ namespace Interactables.Balloon
             loopingAudioSource.Play();
             Vector2 targetPosition = _rigidbody.position + offset;
             player.transform.position = targetPosition;
-            _lineRenderer.enabled = true;
-            _lineRenderer.SetPosition(1, transform.InverseTransformPoint(targetPosition));
+            _ropeRenderer.Attach(transform.InverseTransformPoint(targetPosition));
             _player.AddPlayerVelocityEffector(this);
             StartMotion();
         }
@@ -298,7 +297,7 @@ namespace Interactables.Balloon
                 boostDirection = Vector2.up; // Default to an upward boost
             _player.AddPlayerVelocityEffector(new BonusEndImpulseEffector(_player, boostDirection, exitVelBoost), true);
             loopingAudioSource.Stop();
-            _lineRenderer.enabled = false;
+            _ropeRenderer.Detach();
             _balloonFunnyVisual.gameObject.SetActive(true);
         }
 

--- a/Assets/Scripts/Knitby/KnitbyAnimator.cs
+++ b/Assets/Scripts/Knitby/KnitbyAnimator.cs
@@ -1,5 +1,6 @@
 using Managers;
 using UnityEngine;
+using Util;
 
 namespace Knitby
 {
@@ -120,6 +121,7 @@ namespace Knitby
             anim.SetBool(SwingKey, false);
             anim.SetBool(WaitKey, false);
             anim.SetBool(PlayerDeadKey, false);
+            AnimatorUtil.ResetAnimator(anim, "Run");
         }
     }
 }

--- a/Assets/Scripts/Knitby/KnitbyAnimator.cs
+++ b/Assets/Scripts/Knitby/KnitbyAnimator.cs
@@ -21,8 +21,11 @@ namespace Knitby
         private static readonly int WaitKey = Animator.StringToHash("Wait");
         private static readonly int PlayerDeadKey = Animator.StringToHash("PlayerDead");
         private static readonly int FadeControl = Shader.PropertyToID("_FadeControl");
+        
         [SerializeField] private Animator anim;
+        [SerializeField] private string defaultAnimationState = "Jump";
         [SerializeField] private GameObject deathSmoke;
+        
         private KnitbyController _knitbyController;
         private Material _material;
 
@@ -121,7 +124,7 @@ namespace Knitby
             anim.SetBool(SwingKey, false);
             anim.SetBool(WaitKey, false);
             anim.SetBool(PlayerDeadKey, false);
-            AnimatorUtil.ResetAnimator(anim, "Run");
+            AnimatorUtil.ResetAnimator(anim, defaultAnimationState);
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerAnimator.cs
+++ b/Assets/Scripts/Player/PlayerAnimator.cs
@@ -332,7 +332,8 @@ namespace Player
         // }
 
         /// <summary>
-        ///     On reset, re-activate sprites and make them full opacity
+        ///     On reset, re-activate sprites, make them full opacity.
+        ///     Also reset all animation keys.
         /// </summary>
         private void OnReset()
         {
@@ -341,6 +342,7 @@ namespace Player
                 child.gameObject.SetActive(true);
                 FadeEffects.GetFadeEffectHandler(child, 1).SetAlpha(1);
             }
+            AnimatorUtil.ResetAnimator(anim, "Run");
         }
 
         #endregion

--- a/Assets/Scripts/Player/PlayerAnimator.cs
+++ b/Assets/Scripts/Player/PlayerAnimator.cs
@@ -55,6 +55,7 @@ namespace Player
         [SerializeField] private AudioClip[] deathSounds;
     
         [Header("Visual")]
+        [SerializeField] private string defaultAnimationState = "Run";
         [Tooltip("Player position offset when hanging onto object (small red wire sphere gizmo)")]
         [SerializeField] private Vector2 hangOffset;
         // @formatter:on
@@ -342,7 +343,7 @@ namespace Player
                 child.gameObject.SetActive(true);
                 FadeEffects.GetFadeEffectHandler(child, 1).SetAlpha(1);
             }
-            AnimatorUtil.ResetAnimator(anim, "Run");
+            AnimatorUtil.ResetAnimator(anim, defaultAnimationState);
         }
 
         #endregion

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -67,7 +67,7 @@ namespace Player
         [SerializeField][Range(0, 1)][Tooltip("Multiplier of swing angle")] private float swingDeltaMultiplier = 0.5f;
         [Header("Visual")]
         [SerializeField, Min(0)] private float runParticleVelocityThreshold = 0.1f;
-        [SerializeField] private LineRenderer ropeRenderer;
+        [SerializeField] private RopeRenderer ropeRenderer;
         [SerializeField] private float deathTime;
         // this is just here for battle of the concepts
         [Header("Temporary")]
@@ -267,7 +267,6 @@ namespace Player
             _time += Time.deltaTime;
 
             GetInput();
-            RedrawRope(); // TODO this should be moved outside player controller when knitby is real
         }
 
         private void OnDestroy()
@@ -761,9 +760,9 @@ namespace Player
                 PlayerState = PlayerStateEnum.Swing;
                 _audioSource.clip = swingAttach;
                 _audioSource.Play();
-                ropeRenderer.enabled = true;
                 SwingChanged?.Invoke(true);
                 HangChanged?.Invoke(true, _velocity.x < 0);
+                ropeRenderer.Attach(_swingArea.transform.position);
             }
             else if (PlayerState is PlayerStateEnum.Swing && _isButtonHeld)
             {
@@ -846,7 +845,7 @@ namespace Player
                 // swinging but button is released
                 // stop swinging, disallow swing until reentering area
                 PlayerState = PlayerStateEnum.Air;
-                ropeRenderer.enabled = false;
+                ropeRenderer.Detach();
                 _canSwing = false;
                 _audioSource.clip = swingDetach;
                 _audioSource.Play();
@@ -879,16 +878,6 @@ namespace Player
             // yes, this is meant to be Atan2(x, y) as we want the vector perpendicular
             float angle = Mathf.Atan2(diff.x, -diff.y) * Mathf.Rad2Deg;
             transform.localEulerAngles = new Vector3(0, 0, Mathf.LerpAngle(angle, 0, 1 - swingDeltaMultiplier));
-        }
-
-        private void RedrawRope()
-        {
-            if (PlayerState == PlayerStateEnum.Swing)
-            {
-                ropeRenderer.positionCount = 2;
-                ropeRenderer.SetPosition(0, transform.position);
-                ropeRenderer.SetPosition(1, _swingArea.transform.position);
-            }
         }
 
         private void ApplyMovement()
@@ -927,7 +916,6 @@ namespace Player
 
             _playerVelocityEffectors.Clear();
             _impulseVelocityEffectors.Clear();
-            ropeRenderer.enabled = false;
             _swingPos = null;
             PlayerState = PlayerStateEnum.Run;
             _velocity = Vector2.zero;

--- a/Assets/Scripts/Player/RopeRenderer.cs
+++ b/Assets/Scripts/Player/RopeRenderer.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using Managers;
+using UnityEngine;
+
+namespace Player
+{
+    /// <summary>
+    /// Renders animation of rope growing from one point to another
+    /// </summary>
+    [RequireComponent(typeof(LineRenderer))]
+    public class RopeRenderer : MonoBehaviour
+    {
+        [SerializeField] private float ropeGrowDuration = 0.3f;
+        [SerializeField] private bool growFromSelfToAttachPoint = true;
+
+        private LineRenderer _ropeRenderer;
+        private Vector3 _attachPos;
+        private Coroutine _growRoutine;
+
+        private void Awake()
+        {
+            _ropeRenderer = GetComponent<LineRenderer>();
+            _ropeRenderer.positionCount = 2;
+            _ropeRenderer.enabled = false;
+        }
+
+        private void Update()
+        {
+            if (!_ropeRenderer.enabled) return;
+            _ropeRenderer.SetPosition(growFromSelfToAttachPoint ? 0 : 1, transform.position);
+        }
+
+        public void Attach(Vector3 attachPos)
+        {
+            _attachPos = attachPos;
+
+            if (_growRoutine != null)
+                StopCoroutine(_growRoutine);
+
+            _ropeRenderer.enabled = true;
+            _growRoutine = StartCoroutine(GrowRope());
+        }
+
+        public void Detach()
+        {
+            if (_growRoutine != null)
+                StopCoroutine(_growRoutine);
+
+            _ropeRenderer.enabled = false;
+        }
+
+        private IEnumerator GrowRope()
+        {
+            float t = 0f;
+
+            while (t < 1f)
+            {
+                t += Time.deltaTime / ropeGrowDuration;
+                float lerp = Mathf.Clamp01(t);
+
+                if (growFromSelfToAttachPoint)
+                {
+                    _ropeRenderer.SetPosition(0, transform.position);
+                    _ropeRenderer.SetPosition(1, Vector3.Lerp(transform.position, _attachPos, lerp));
+                }
+                else
+                {
+                    _ropeRenderer.SetPosition(0, Vector3.Lerp(_attachPos, transform.position, lerp));
+                    _ropeRenderer.SetPosition(1, transform.position);
+                }
+
+                yield return null;
+            }
+
+            if (growFromSelfToAttachPoint)
+            {
+                _ropeRenderer.SetPosition(0, transform.position);
+                _ropeRenderer.SetPosition(1, _attachPos);
+            }
+            else
+            {
+                _ropeRenderer.SetPosition(0, _attachPos);
+                _ropeRenderer.SetPosition(1, transform.position);
+            }
+        }
+
+        private void OnEnable()
+        {
+            GameManager.Instance.Reset += OnReset;
+        }
+
+        private void OnDisable()
+        {
+            GameManager.Instance.Reset -= OnReset;
+        }
+
+        private void OnReset()
+        {
+            Detach();
+        }
+    }
+}

--- a/Assets/Scripts/Player/RopeRenderer.cs
+++ b/Assets/Scripts/Player/RopeRenderer.cs
@@ -10,7 +10,7 @@ namespace Player
     [RequireComponent(typeof(LineRenderer))]
     public class RopeRenderer : MonoBehaviour
     {
-        [SerializeField] private float ropeGrowDuration = 0.3f;
+        [SerializeField, Min(0)] private float ropeGrowDuration = 0.3f;
         [SerializeField] private bool growFromSelfToAttachPoint = true;
         [SerializeField] private bool useWorldSpace = true;
 
@@ -57,22 +57,18 @@ namespace Player
         private IEnumerator GrowRope()
         {
             Vector3 selfPos = useWorldSpace ? transform.position : transform.localPosition;
-            float t = 0f;
-
-            while (t < 1f)
+            for (float t = 0f; t < 1f; t += Time.deltaTime / ropeGrowDuration)
             {
-                t += Time.deltaTime / ropeGrowDuration;
-                float lerp = Mathf.Clamp01(t);
                 selfPos = useWorldSpace ? transform.position : transform.localPosition;
 
                 if (growFromSelfToAttachPoint)
                 {
                     _lineRenderer.SetPosition(0, selfPos);
-                    _lineRenderer.SetPosition(1, Vector3.Lerp(selfPos, _attachPos, lerp));
+                    _lineRenderer.SetPosition(1, Vector2.Lerp(selfPos, _attachPos, t));
                 }
                 else
                 {
-                    _lineRenderer.SetPosition(0, Vector3.Lerp(_attachPos, selfPos, lerp));
+                    _lineRenderer.SetPosition(0, Vector2.Lerp(_attachPos, selfPos, t));
                     _lineRenderer.SetPosition(1, selfPos);
                 }
 

--- a/Assets/Scripts/Player/RopeRenderer.cs
+++ b/Assets/Scripts/Player/RopeRenderer.cs
@@ -12,22 +12,27 @@ namespace Player
     {
         [SerializeField] private float ropeGrowDuration = 0.3f;
         [SerializeField] private bool growFromSelfToAttachPoint = true;
+        [SerializeField] private bool useWorldSpace = true;
 
-        private LineRenderer _ropeRenderer;
+        private LineRenderer _lineRenderer;
         private Vector3 _attachPos;
         private Coroutine _growRoutine;
 
         private void Awake()
         {
-            _ropeRenderer = GetComponent<LineRenderer>();
-            _ropeRenderer.positionCount = 2;
-            _ropeRenderer.enabled = false;
+            _lineRenderer = GetComponent<LineRenderer>();
+            _lineRenderer.enabled = false;
+            _lineRenderer.positionCount = 2;
+            _lineRenderer.SetPosition(growFromSelfToAttachPoint ? 0 : 1, transform.position);
         }
 
         private void Update()
         {
-            if (!_ropeRenderer.enabled) return;
-            _ropeRenderer.SetPosition(growFromSelfToAttachPoint ? 0 : 1, transform.position);
+            if (!_lineRenderer.enabled) return;
+            _lineRenderer.SetPosition(
+                growFromSelfToAttachPoint ? 0 : 1,
+                useWorldSpace ? transform.position : transform.localPosition
+            );
         }
 
         public void Attach(Vector3 attachPos)
@@ -37,7 +42,7 @@ namespace Player
             if (_growRoutine != null)
                 StopCoroutine(_growRoutine);
 
-            _ropeRenderer.enabled = true;
+            _lineRenderer.enabled = true;
             _growRoutine = StartCoroutine(GrowRope());
         }
 
@@ -46,27 +51,29 @@ namespace Player
             if (_growRoutine != null)
                 StopCoroutine(_growRoutine);
 
-            _ropeRenderer.enabled = false;
+            _lineRenderer.enabled = false;
         }
 
         private IEnumerator GrowRope()
         {
+            Vector3 selfPos = useWorldSpace ? transform.position : transform.localPosition;
             float t = 0f;
 
             while (t < 1f)
             {
                 t += Time.deltaTime / ropeGrowDuration;
                 float lerp = Mathf.Clamp01(t);
+                selfPos = useWorldSpace ? transform.position : transform.localPosition;
 
                 if (growFromSelfToAttachPoint)
                 {
-                    _ropeRenderer.SetPosition(0, transform.position);
-                    _ropeRenderer.SetPosition(1, Vector3.Lerp(transform.position, _attachPos, lerp));
+                    _lineRenderer.SetPosition(0, selfPos);
+                    _lineRenderer.SetPosition(1, Vector3.Lerp(selfPos, _attachPos, lerp));
                 }
                 else
                 {
-                    _ropeRenderer.SetPosition(0, Vector3.Lerp(_attachPos, transform.position, lerp));
-                    _ropeRenderer.SetPosition(1, transform.position);
+                    _lineRenderer.SetPosition(0, Vector3.Lerp(_attachPos, selfPos, lerp));
+                    _lineRenderer.SetPosition(1, selfPos);
                 }
 
                 yield return null;
@@ -74,13 +81,13 @@ namespace Player
 
             if (growFromSelfToAttachPoint)
             {
-                _ropeRenderer.SetPosition(0, transform.position);
-                _ropeRenderer.SetPosition(1, _attachPos);
+                _lineRenderer.SetPosition(0, selfPos);
+                _lineRenderer.SetPosition(1, _attachPos);
             }
             else
             {
-                _ropeRenderer.SetPosition(0, _attachPos);
-                _ropeRenderer.SetPosition(1, transform.position);
+                _lineRenderer.SetPosition(0, _attachPos);
+                _lineRenderer.SetPosition(1, selfPos);
             }
         }
 

--- a/Assets/Scripts/Player/RopeRenderer.cs.meta
+++ b/Assets/Scripts/Player/RopeRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82fcbdc2eeb8af3409ddc0e898105c1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/AnimatorUtil.cs
+++ b/Assets/Scripts/Util/AnimatorUtil.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace Util
+{
+    public static class AnimatorUtil
+    {
+        /// <summary>
+        /// Reset all animation keys (triggers, booleans, integers) of an animation
+        /// and set the animation to the default animation state.
+        /// </summary>
+        /// <param name="animator">Animator to be reset.</param>
+        /// <param name="defaultAnimationState">Name of the default animation state.</param>
+        public static void ResetAnimator(Animator animator, string defaultAnimationState)
+        {
+            foreach (AnimatorControllerParameter param in animator.parameters)
+            {
+                switch (param.type)
+                {
+                    case AnimatorControllerParameterType.Trigger:
+                        animator.ResetTrigger(param.name);
+                        break;
+                    case AnimatorControllerParameterType.Bool:
+                        animator.SetBool(param.name, false);
+                        break;
+                    case AnimatorControllerParameterType.Int:
+                        animator.SetInteger(param.name, 0);
+                        break;
+                    case AnimatorControllerParameterType.Float:
+                        animator.SetFloat(param.name, 0f);
+                        break;
+                }
+            }
+        
+            animator.Play(defaultAnimationState);
+        }
+    }
+}

--- a/Assets/Scripts/Util/AnimatorUtil.cs.meta
+++ b/Assets/Scripts/Util/AnimatorUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33d93953ec993b14f98999c7d99b22c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
<!-- What changes does this PR include? Is there anything that affects other features that people should be aware of? -->
- Instead of instantly appearing, string renders from one point to another. Applies for both swings and balloons.
_Man I thought this would've looked cooler it's honestly barely noticeable...
Oh well it's still good coding practice x_x_
- Bug fix: Reset animation on respawn. Previously if you die while wallsliding/hanging onto something you could respawn while maintaining that animation

## Before and After
<!-- Screenshots/videos of the changes: -->
https://github.com/user-attachments/assets/8b9f9854-ff8c-4cc0-aef0-a22c19a6081f

## Checklist (for devs)
- [x] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
- [x] Tested changes in Unity
- [x] Prefab overrides are applied or reverted where relevant
- [x] All meta files are committed
- [x] Checked Github's "Files changed" tab for unintended changes
- [x] Files, classes, and complex methods are documented 
