### PR TITLE
Surfing the tsunami

### DIFF
--- a/Assets/Scripts/Managers/TimerManager.cs
+++ b/Assets/Scripts/Managers/TimerManager.cs
@@ -1,4 +1,5 @@
 using System;
+using Save;
 using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -47,6 +48,7 @@ namespace Managers
                                              SceneListManager.Instance.InMainMenu;
         
         private bool _isNotForceDisabled = true;
+        private LastCheckpoint _lastCheckpoint;
 
         private void Awake()
         {
@@ -60,6 +62,11 @@ namespace Managers
         private void OnDestroy()
         {
             SceneManager.sceneLoaded -= OnSceneLoaded;
+            if (_lastCheckpoint)
+            {
+                _lastCheckpoint.AttachedCheckpoint.onCheckpointReached.RemoveListener(HandleFinalCheckpointHit);
+                _lastCheckpoint = null;
+            }
         }
 
         private void Update()
@@ -79,6 +86,16 @@ namespace Managers
         /// <param name="mode">Scene load mode</param>
         private void OnSceneLoaded(Scene newScene, LoadSceneMode mode)
         {
+            if (_lastCheckpoint)
+            {
+                _lastCheckpoint.AttachedCheckpoint.onCheckpointReached.RemoveListener(HandleFinalCheckpointHit);
+                _lastCheckpoint = null;
+            }
+            _lastCheckpoint = FindAnyObjectByType<LastCheckpoint>();
+            if (_lastCheckpoint)
+            {
+                _lastCheckpoint.AttachedCheckpoint.onCheckpointReached.AddListener(HandleFinalCheckpointHit);
+            }
             _isNotForceDisabled = true;
             //only reset time when in a level, not in a cutscene
             if (!SceneListManager.Instance.InCutscene)
@@ -86,6 +103,17 @@ namespace Managers
                 ElapsedLevelTime = 0;
             }
             UpdateFromPrefs();
+        }
+
+        /// <summary>
+        /// On final checkpoint hit hide the timer.
+        /// </summary>
+        /// <remarks>
+        /// Don't worry, we'll re-show it on scene load.
+        /// </remarks>
+        private void HandleFinalCheckpointHit()
+        {
+            SetTimerState(false);
         }
 
         /// <summary>

--- a/Assets/Scripts/Managers/TimerManager.cs
+++ b/Assets/Scripts/Managers/TimerManager.cs
@@ -42,7 +42,7 @@ namespace Managers
         /// <summary>
         /// Whether the timer should be hidden even if the setting is enabled.
         /// </summary>
-        private bool ShouldDisableTimer => !_isNotForceDisabled || resultsWindow.activeSelf ||
+        private bool ShouldDisableTimer => !_isNotForceDisabled ||
                                              SceneListManager.Instance.InCutscene ||
                                              SceneListManager.Instance.InMainMenu;
         

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -392,7 +392,7 @@ namespace Player
             Debug.Assert(CurrentInteractableArea == interactable,
                 $"Requested to stop interaction on inactive interactable: {interactable} vs Current {CurrentInteractableArea}");
             _buttonNotPressedPreviousFrame = true;
-            CurrentInteractableArea.EndInteract(this);
+            if (CurrentInteractableArea) CurrentInteractableArea.EndInteract(this);
             PlayerState = PlayerStateEnum.Air;
             HangChanged?.Invoke(false, _velocity.x < 0);
         }


### PR DESCRIPTION
## Description
- pushing to prod 11pm the day before
  - NPE on dying with an interactable that auto-kicks you off
  - fix timer incorrectly hiding after restart + not hiding after results screen

## Before and After
ehh

## Checklist (for devs)
- [X] ❗These changes follow [best practices to minimise lag](https://www.notion.so/Codebase-13de52a73bd68145a623f87a70de6a38)
- [X] Tested changes in Unity
- [X] Prefab overrides are applied or reverted where relevant
- [X] All meta files are committed
- [X] Checked Github's "Files changed" tab for unintended changes
- [X] Files, classes, and complex methods are documented 
